### PR TITLE
Enable a ctrl-w shortcut to close the top window

### DIFF
--- a/argos/app.py
+++ b/argos/app.py
@@ -355,7 +355,8 @@ class Application(Gtk.Application):
                 "as",
                 None,
             ),
-            ("quit", self.quit_activate_cb, None, ("app.quit", ["<Ctrl>Q"])),
+            ("close-window", self.win_close_cb, None, ("app.close-window", ["<Primary>W"])),
+            ("quit", self.quit_activate_cb, None, ("app.quit", ["<Primary>Q"])),
         ]
         for action_name, callback, params_type_desc, accel in action_descriptions:
             params_type = (
@@ -486,6 +487,16 @@ class Application(Gtk.Application):
             self.prefs_window.destroy()
 
         self.prefs_window = None
+
+    def win_close_cb(self, action: Gio.SimpleAction, parameter: None) -> None:
+        LOGGER.debug("Window close requested by end-user")
+
+        if self.prefs_window:
+            self.prefs_window.destroy()
+            self.prefs_window = None
+        elif self.window is not None:
+            self._stop_event_loop()
+            self.window.destroy()
 
     def quit_activate_cb(self, action: Gio.SimpleAction, parameter: None) -> None:
         LOGGER.debug("Quit requested by end-user")

--- a/argos/ui/help_overlay.ui
+++ b/argos/ui/help_overlay.ui
@@ -15,6 +15,13 @@
               <object class="GtkShortcutsShortcut">
                 <property name="visible">True</property>
                 <property name="title" translatable="yes" context="shortcut window">Close window</property>
+                <property name="accelerator">&lt;Primary&gt;W</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="visible">True</property>
+                <property name="title" translatable="yes" context="shortcut window">Quit app</property>
                 <property name="accelerator">&lt;Primary&gt;Q</property>
               </object>
             </child>


### PR DESCRIPTION
My fingers default to ctrl-w to close tabs and windows, so this attempts to add a ctrl-w accel. Since it's handled at the app layer instead of a specific window, it closes the preferences window if it's open, even if the user has focused the main window, but that's probably fine? And the shortcuts dialog doesn't work with ctrl-q or ctrl-w at all, just the escape key.